### PR TITLE
Add `long` support

### DIFF
--- a/src/Sqids/CastExtensions.cs
+++ b/src/Sqids/CastExtensions.cs
@@ -1,0 +1,20 @@
+namespace Sqids;
+
+internal static class CastExtensions
+{
+	/// <summary>
+	/// Casts collection of <see cref="Int32"/> to collection of <see cref="Int64"/>
+	/// </summary>
+	/// <param name="source">Source collection</param>
+	/// <returns>Collection of <see cref="Int64"/></returns>
+	public static IEnumerable<long> CastToInt64(this IEnumerable<int> source) =>
+		source.Select(value => (long)value);
+
+	/// <summary>
+	/// Casts collection of <see cref="Int64"/> to collection of <see cref="Int32"/>
+	/// </summary>
+	/// <param name="source">Source collection</param>
+	/// <returns>Collection of <see cref="Int32"/></returns>
+	public static IEnumerable<int> CastToInt32(this IEnumerable<long> source) =>
+		source.Select(value => (int)value);
+}

--- a/src/Sqids/SqidsEncoder.cs
+++ b/src/Sqids/SqidsEncoder.cs
@@ -85,6 +85,16 @@ public sealed class SqidsEncoder
 	}
 
 	/// <summary>
+	/// Encodes a single number into a Sqids ID.
+	/// </summary>
+	/// <param name="number">The number to encode.</param>
+	/// <returns>A string containing the encoded ID.</returns>
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string EncodeInt(int number) =>
+		Encode((long)number);
+
+	/// <summary>
 	/// Encodes multiple numbers into a Sqids ID.
 	/// </summary>
 	/// <param name="numbers">The numbers to encode.</param>
@@ -103,6 +113,16 @@ public sealed class SqidsEncoder
 	}
 
 	/// <summary>
+	/// Encodes multiple numbers into a Sqids ID.
+	/// </summary>
+	/// <param name="numbers">The numbers to encode.</param>
+	/// <returns>A string containing the encoded IDs, or an empty string if the array passed is empty.</returns>
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string EncodeInt(params int[] numbers) =>
+		Encode(numbers.CastToInt64().ToArray());
+
+	/// <summary>
 	/// Encodes a collection of numbers into a Sqids ID.
 	/// </summary>
 	/// <param name="numbers">The numbers to encode.</param>
@@ -111,6 +131,16 @@ public sealed class SqidsEncoder
 	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
 	public string Encode(IEnumerable<long> numbers) =>
 		Encode(numbers.ToArray());
+
+	/// <summary>
+	/// Encodes a collection of numbers into a Sqids ID.
+	/// </summary>
+	/// <param name="numbers">The numbers to encode.</param>
+	/// <returns>A string containing the encoded IDs, or an empty string if the `IEnumerable` passed is empty.</returns>
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string EncodeInt(IEnumerable<int> numbers) =>
+		Encode(numbers.CastToInt64());
 
 	// TODO: Consider using `ArrayPool` if possible
 	private string Encode(ReadOnlySpan<long> numbers, bool partitioned = false)
@@ -277,6 +307,18 @@ public sealed class SqidsEncoder
 		return result.ToArray(); // TODO: A way to return an array without creating a new array from the list like this?
 	}
 
+	/// <summary>
+	/// Decodes an ID into numbers.
+	/// </summary>
+	/// <param name="id">The encoded ID.</param>
+	/// <returns>
+	/// An array of long integers containing the decoded number(s) (it would contain only one element
+	/// if the ID represents a single number); or an empty array if the input ID is null,
+	/// empty, or includes characters not found in the alphabet.
+	/// </returns>
+	public int[] DecodeInt(ReadOnlySpan<char> id) =>
+		Decode(id).CastToInt32().ToArray();
+
 	// NOTE: Implicit `string` => `Span<char>` conversion was introduced in .NET Standard 2.1 (see https://learn.microsoft.com/en-us/dotnet/api/system.string.op_implicit), which means without this overload, calling `Decode` with a string on versions older than .NET Standard 2.1 would require calling `.AsSpan()` on the string, which is cringe.
 #if NETSTANDARD2_0
 	/// <summary>
@@ -289,6 +331,17 @@ public sealed class SqidsEncoder
 	/// empty, or includes characters not found in the alphabet.
 	/// </returns>
 	public long[] Decode(string id) => Decode(id.AsSpan());
+
+	/// <summary>
+	/// Decodes an ID into numbers.
+	/// </summary>
+	/// <param name="id">The encoded ID.</param>
+	/// <returns>
+	/// An array of long integers containing the decoded number(s) (it would contain only one element
+	/// if the ID represents a single number); or an empty array if the input ID is null,
+	/// empty, or includes characters not found in the alphabet.
+	/// </returns>
+	public int[] DecodeInt(string id) => DecodeInt(id.AsSpan());
 #endif
 
 	private bool IsBlockedId(ReadOnlySpan<char> id)

--- a/src/Sqids/SqidsEncoder.cs
+++ b/src/Sqids/SqidsEncoder.cs
@@ -16,13 +16,13 @@ public sealed class SqidsEncoder
 	/// The minimum numeric value that can be encoded/decoded using <see cref="SqidsEncoder" />.
 	/// This is always zero across all ports of Sqids.
 	/// </summary>
-	public const int MinValue = 0;
+	public const long MinValue = 0;
 
 	/// <summary>
 	/// The maximum numeric value that can be encoded/decoded using <see cref="SqidsEncoder" />.
-	/// It's equal to `int.MaxValue`.
+	/// It's equal to `long.MaxValue`.
 	/// </summary>
-	public const int MaxValue = int.MaxValue;
+	public const long MaxValue = long.MaxValue;
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="SqidsEncoder" /> with the default options.
@@ -74,9 +74,9 @@ public sealed class SqidsEncoder
 	/// </summary>
 	/// <param name="number">The number to encode.</param>
 	/// <returns>A string containing the encoded ID.</returns>
-	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `int.MaxValue`).</exception>
-	/// <exception cref="T:System.OverflowException">If the decoded number overflows integer.</exception>
-	public string Encode(int number)
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string Encode(long number)
 	{
 		if (number < MinValue || number > MaxValue)
 			throw new ArgumentOutOfRangeException($"Encoding supports numbers between '{MinValue}' and '{MaxValue}'.");
@@ -89,9 +89,9 @@ public sealed class SqidsEncoder
 	/// </summary>
 	/// <param name="numbers">The numbers to encode.</param>
 	/// <returns>A string containing the encoded IDs, or an empty string if the array passed is empty.</returns>
-	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `int.MaxValue`).</exception>
-	/// <exception cref="T:System.OverflowException">If the decoded number overflows integer.</exception>
-	public string Encode(params int[] numbers)
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string Encode(params long[] numbers)
 	{
 		if (numbers.Length == 0)
 			return string.Empty;
@@ -107,13 +107,13 @@ public sealed class SqidsEncoder
 	/// </summary>
 	/// <param name="numbers">The numbers to encode.</param>
 	/// <returns>A string containing the encoded IDs, or an empty string if the `IEnumerable` passed is empty.</returns>
-	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `int.MaxValue`).</exception>
-	/// <exception cref="T:System.OverflowException">If the decoded number overflows integer.</exception>
-	public string Encode(IEnumerable<int> numbers) =>
+	/// <exception cref="T:System.ArgumentOutOfRangeException">If any of the long integers passed is smaller than <see cref="MinValue"/> (i.e. negative) or greater than <see cref="MaxValue"/> (i.e. `long.MaxValue`).</exception>
+	/// <exception cref="T:System.OverflowException">If the decoded number overflows long integer.</exception>
+	public string Encode(IEnumerable<long> numbers) =>
 		Encode(numbers.ToArray());
 
 	// TODO: Consider using `ArrayPool` if possible
-	private string Encode(ReadOnlySpan<int> numbers, bool partitioned = false)
+	private string Encode(ReadOnlySpan<long> numbers, bool partitioned = false)
 	{
 		int offset = 0;
 		for (int i = 0; i < numbers.Length; i++)
@@ -136,7 +136,7 @@ public sealed class SqidsEncoder
 
 		for (int i = 0; i < numbers.Length; i++)
 		{
-			int number = numbers[i];
+			long number = numbers[i];
 
 			var alphabetWithoutSeparator = alphabetTemp[..^1];
 			var encodedNumber = ToId(number, alphabetWithoutSeparator);
@@ -162,9 +162,9 @@ public sealed class SqidsEncoder
 		{
 			if (!partitioned)
 			{
-				Span<int> newNumbers = (numbers.Length + 1) * sizeof(int) > MaxStackallocSize
-					? new int[numbers.Length + 1]
-					: stackalloc int[numbers.Length + 1];
+				Span<long> newNumbers = (numbers.Length + 1) * sizeof(long) > MaxStackallocSize
+					? new long[numbers.Length + 1]
+					: stackalloc long[numbers.Length + 1];
 				newNumbers[0] = 0;
 				numbers.CopyTo(newNumbers[1..]);
 				result = Encode(newNumbers, partitioned: true);
@@ -181,9 +181,9 @@ public sealed class SqidsEncoder
 
 		if (IsBlockedId(result.AsSpan()))
 		{
-			Span<int> newNumbers = numbers.Length * sizeof(int) > MaxStackallocSize
-				? new int[numbers.Length]
-				: stackalloc int[numbers.Length];
+			Span<long> newNumbers = numbers.Length * sizeof(long) > MaxStackallocSize
+				? new long[numbers.Length]
+				: stackalloc long[numbers.Length];
 			numbers.CopyTo(newNumbers);
 
 			if (partitioned)
@@ -195,9 +195,9 @@ public sealed class SqidsEncoder
 			}
 			else
 			{
-				newNumbers = (numbers.Length + 1) * sizeof(int) > MaxStackallocSize
-					? new int[numbers.Length + 1]
-					: stackalloc int[numbers.Length + 1];
+				newNumbers = (numbers.Length + 1) * sizeof(long) > MaxStackallocSize
+					? new long[numbers.Length + 1]
+					: stackalloc long[numbers.Length + 1];
 				newNumbers[0] = 0;
 				numbers.CopyTo(newNumbers[1..]);
 			}
@@ -213,18 +213,18 @@ public sealed class SqidsEncoder
 	/// </summary>
 	/// <param name="id">The encoded ID.</param>
 	/// <returns>
-	/// An array of integers containing the decoded number(s) (it would contain only one element
+	/// An array of long integers containing the decoded number(s) (it would contain only one element
 	/// if the ID represents a single number); or an empty array if the input ID is null,
 	/// empty, or includes characters not found in the alphabet.
 	/// </returns>
-	public int[] Decode(ReadOnlySpan<char> id)
+	public long[] Decode(ReadOnlySpan<char> id)
 	{
 		if (id.IsEmpty)
-			return Array.Empty<int>();
+			return Array.Empty<long>();
 
 		foreach (char c in id)
 			if (!_alphabet.Contains(c))
-				return Array.Empty<int>();
+				return Array.Empty<long>();
 
 		var alphabetSpan = _alphabet.AsSpan();
 
@@ -248,7 +248,7 @@ public sealed class SqidsEncoder
 			ConsistentShuffle(alphabetTemp);
 		}
 
-		var result = new List<int>();
+		var result = new List<long>();
 
 		while (!id.IsEmpty)
 		{
@@ -265,7 +265,7 @@ public sealed class SqidsEncoder
 
 			foreach (char c in chunk)
 				if (!alphabetWithoutSeparator.Contains(c))
-					return Array.Empty<int>();
+					return Array.Empty<long>();
 
 			var decodedNumber = ToNumber(chunk, alphabetWithoutSeparator);
 			result.Add(decodedNumber);
@@ -284,11 +284,11 @@ public sealed class SqidsEncoder
 	/// </summary>
 	/// <param name="id">The encoded ID.</param>
 	/// <returns>
-	/// An array of integers containing the decoded number(s) (it would contain only one element
+	/// An array of long integers containing the decoded number(s) (it would contain only one element
 	/// if the ID represents a single number); or an empty array if the input ID is null,
 	/// empty, or includes characters not found in the alphabet.
 	/// </returns>
-	public int[] Decode(string id) => Decode(id.AsSpan());
+	public long[] Decode(string id) => Decode(id.AsSpan());
 #endif
 
 	private bool IsBlockedId(ReadOnlySpan<char> id)
@@ -324,23 +324,23 @@ public sealed class SqidsEncoder
 		}
 	}
 
-	private static ReadOnlySpan<char> ToId(int num, ReadOnlySpan<char> alphabet)
+	private static ReadOnlySpan<char> ToId(long num, ReadOnlySpan<char> alphabet)
 	{
 		var id = new StringBuilder();
-		int result = num;
+		long result = num;
 
 		do
 		{
-			id.Insert(0, alphabet[result % alphabet.Length]);
+			id.Insert(0, alphabet[(int)(result % alphabet.Length)]);
 			result = result / alphabet.Length;
 		} while (result > 0);
 
 		return id.ToString().AsSpan(); // TODO: possibly avoid creating a string
 	}
 
-	private static int ToNumber(ReadOnlySpan<char> id, ReadOnlySpan<char> alphabet)
+	private static long ToNumber(ReadOnlySpan<char> id, ReadOnlySpan<char> alphabet)
 	{
-		int result = 0;
+		long result = 0;
 		foreach (var character in id)
 			result = result * alphabet.Length + alphabet.IndexOf(character);
 		return result;

--- a/test/Sqids.Tests/AlphabetTests.cs
+++ b/test/Sqids.Tests/AlphabetTests.cs
@@ -2,10 +2,10 @@ namespace Sqids.Tests;
 
 public class AlphabetTests
 {
-	[TestCase("0123456789abcdef", new[] { 1, 2, 3 }, "4d9fd2")]
+	[TestCase("0123456789abcdef", new long[] { 1, 2, 3 }, "4d9fd2")]
 	public void EncodeAndDecode_WithCustomAlphabet_ReturnsExactMatch(
 		string alphabet,
-		int[] numbers,
+		long[] numbers,
 		string id
 	)
 	{
@@ -15,11 +15,11 @@ public class AlphabetTests
 		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
 	}
 
-	[TestCase("abcde", new[] { 1, 2, 3 })] // NOTE: Short alphabet
-	[TestCase("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_+|{}[];:'\"/?.>,<`~", new[] { 1, 2, 3 })] // NOTE: Long short
+	[TestCase("abcde", new long[] { 1, 2, 3 })] // NOTE: Short alphabet
+	[TestCase("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_+|{}[];:'\"/?.>,<`~", new long[] { 1, 2, 3 })] // NOTE: Long short
 	public void EncodeAndDecode_WithCustomAlphabet_RoundTripsSuccessfully(
 		string alphabet,
-		int[] numbers
+		long[] numbers
 	)
 	{
 		var sqids = new SqidsEncoder(new() { Alphabet = alphabet });

--- a/test/Sqids.Tests/BlockListTests.cs
+++ b/test/Sqids.Tests/BlockListTests.cs
@@ -7,7 +7,7 @@ public class BlockListTests
 	{
 		var sqids = new SqidsEncoder();
 
-		sqids.Decode("sexy").ShouldBeEquivalentTo(new[] { 200044 });
+		sqids.Decode("sexy").ShouldBeEquivalentTo(new long[] { 200044 });
 		sqids.Encode(200044).ShouldBe("d171vI");
 	}
 
@@ -19,7 +19,7 @@ public class BlockListTests
 			BlockList = new(),
 		});
 
-		sqids.Decode("sexy").ShouldBeEquivalentTo(new[] { 200044 });
+		sqids.Decode("sexy").ShouldBeEquivalentTo(new long[] { 200044 });
 		sqids.Encode(200044).ShouldBe("sexy");
 	}
 
@@ -35,13 +35,13 @@ public class BlockListTests
 		});
 
 		// NOTE: Make sure the default blocklist isn't used
-		sqids.Decode("sexy").ShouldBeEquivalentTo(new[] { 200044 });
+		sqids.Decode("sexy").ShouldBeEquivalentTo(new long[] { 200044 });
 		sqids.Encode(200044).ShouldBe("sexy");
 
 		// NOTE: Make sure the passed blocklist IS used:
-		sqids.Decode("AvTg").ShouldBeEquivalentTo(new[] { 100000 });
+		sqids.Decode("AvTg").ShouldBeEquivalentTo(new long[] { 100000 });
 		sqids.Encode(100000).ShouldBe("7T1X8k");
-		sqids.Decode("7T1X8k").ShouldBeEquivalentTo(new[] { 100000 });
+		sqids.Decode("7T1X8k").ShouldBeEquivalentTo(new long[] { 100000 });
 	}
 
 	[Test]
@@ -60,7 +60,7 @@ public class BlockListTests
 		});
 
 		sqids.Encode(1, 2, 3).ShouldBe("TM0x1Mxz");
-		sqids.Decode("TM0x1Mxz").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
+		sqids.Decode("TM0x1Mxz").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
 	}
 
 	[Test]
@@ -78,11 +78,11 @@ public class BlockListTests
 			},
 		});
 
-		sqids.Decode("8QRLaD").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("7T1cd0dL").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("RA8UeIe7").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("WM3Limhw").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("LfUQh4HN").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
+		sqids.Decode("8QRLaD").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
+		sqids.Decode("7T1cd0dL").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
+		sqids.Decode("RA8UeIe7").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
+		sqids.Decode("WM3Limhw").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
+		sqids.Decode("LfUQh4HN").ShouldBeEquivalentTo(new long[] { 1, 2, 3 });
 	}
 
 	[Test]
@@ -96,6 +96,6 @@ public class BlockListTests
 			},
 		});
 
-		sqids.Decode(sqids.Encode(1000)).ShouldBeEquivalentTo(new[] { 1000 });
+		sqids.Decode(sqids.Encode(1000)).ShouldBeEquivalentTo(new long[] { 1000 });
 	}
 }

--- a/test/Sqids.Tests/EncodingTests.cs
+++ b/test/Sqids.Tests/EncodingTests.cs
@@ -18,36 +18,36 @@ public class EncodingTests
 		var sqids = new SqidsEncoder();
 
 		sqids.Encode(number).ShouldBe(id);
-		sqids.Decode(id).ShouldBeEquivalentTo(new[] { number });
+		sqids.Decode(id).ShouldBeEquivalentTo(new long[] { number });
 	}
 
 	// NOTE: Simple case
-	[TestCase(new[] { 1, 2, 3 }, "8QRLaD")]
+	[TestCase(new long[] { 1, 2, 3 }, "8QRLaD")]
 	// NOTE: Incremental
-	[TestCase(new[] { 0, 0 }, "SrIu")]
-	[TestCase(new[] { 0, 1 }, "nZqE")]
-	[TestCase(new[] { 0, 2 }, "tJyf")]
-	[TestCase(new[] { 0, 3 }, "e86S")]
-	[TestCase(new[] { 0, 4 }, "rtC7")]
-	[TestCase(new[] { 0, 5 }, "sQ8R")]
-	[TestCase(new[] { 0, 6 }, "uz2n")]
-	[TestCase(new[] { 0, 7 }, "7Td9")]
-	[TestCase(new[] { 0, 8 }, "3nWE")]
-	[TestCase(new[] { 0, 9 }, "mIxM")]
+	[TestCase(new long[] { 0, 0 }, "SrIu")]
+	[TestCase(new long[] { 0, 1 }, "nZqE")]
+	[TestCase(new long[] { 0, 2 }, "tJyf")]
+	[TestCase(new long[] { 0, 3 }, "e86S")]
+	[TestCase(new long[] { 0, 4 }, "rtC7")]
+	[TestCase(new long[] { 0, 5 }, "sQ8R")]
+	[TestCase(new long[] { 0, 6 }, "uz2n")]
+	[TestCase(new long[] { 0, 7 }, "7Td9")]
+	[TestCase(new long[] { 0, 8 }, "3nWE")]
+	[TestCase(new long[] { 0, 9 }, "mIxM")]
 	// NOTE: Incremental
-	[TestCase(new[] { 0, 0 }, "SrIu")]
-	[TestCase(new[] { 1, 0 }, "nbqh")]
-	[TestCase(new[] { 2, 0 }, "t4yj")]
-	[TestCase(new[] { 3, 0 }, "eQ6L")]
-	[TestCase(new[] { 4, 0 }, "r4Cc")]
-	[TestCase(new[] { 5, 0 }, "sL82")]
-	[TestCase(new[] { 6, 0 }, "uo2f")]
-	[TestCase(new[] { 7, 0 }, "7Zdq")]
-	[TestCase(new[] { 8, 0 }, "36Wf")]
-	[TestCase(new[] { 9, 0 }, "m4xT")]
+	[TestCase(new long[] { 0, 0 }, "SrIu")]
+	[TestCase(new long[] { 1, 0 }, "nbqh")]
+	[TestCase(new long[] { 2, 0 }, "t4yj")]
+	[TestCase(new long[] { 3, 0 }, "eQ6L")]
+	[TestCase(new long[] { 4, 0 }, "r4Cc")]
+	[TestCase(new long[] { 5, 0 }, "sL82")]
+	[TestCase(new long[] { 6, 0 }, "uo2f")]
+	[TestCase(new long[] { 7, 0 }, "7Zdq")]
+	[TestCase(new long[] { 8, 0 }, "36Wf")]
+	[TestCase(new long[] { 9, 0 }, "m4xT")]
 	// NOTE: Empty array should encode into empty string
-	[TestCase(new int[] { }, "")]
-	public void EncodeAndDecode_MultipleNumbers_ReturnsExactMatch(int[] numbers, string id)
+	[TestCase(new long[] { }, "")]
+	public void EncodeAndDecode_MultipleNumbers_ReturnsExactMatch(long[] numbers, string id)
 	{
 		var sqids = new SqidsEncoder();
 
@@ -59,14 +59,14 @@ public class EncodingTests
 	[TestCase(new[] {
 		0, 0, 0, 1, 2, 3, 100, 1_000, 100_000, 1_000_000, SqidsEncoder.MaxValue
 	})]
-	[TestCase(new[] {
+	[TestCase(new long[] {
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
 		25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
 		48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
 		71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93,
 		94, 95, 96, 97, 98, 99
 	})]
-	public void EncodeAndDecode_MultipleNumbers_RoundTripsSuccessfully(int[] numbers)
+	public void EncodeAndDecode_MultipleNumbers_RoundTripsSuccessfully(long[] numbers)
 	{
 		var sqids = new SqidsEncoder();
 

--- a/test/Sqids.Tests/MinLengthTests.cs
+++ b/test/Sqids.Tests/MinLengthTests.cs
@@ -2,18 +2,18 @@ namespace Sqids.Tests;
 
 public class MinLengthTests
 {
-	[TestCase(new[] { 1, 2, 3 }, "75JILToVsGerOADWmHlY38xvbaNZKQ9wdFS0B6kcMEtnRpgizhjU42qT1cd0dL")]
-	[TestCase(new[] { 0, 0 }, "jf26PLNeO5WbJDUV7FmMtlGXps3CoqkHnZ8cYd19yIiTAQuvKSExzhrRghBlwf")]
-	[TestCase(new[] { 0, 1 }, "vQLUq7zWXC6k9cNOtgJ2ZK8rbxuipBFAS10yTdYeRa3ojHwGnmMV4PDhESI2jL")]
-	[TestCase(new[] { 0, 2 }, "YhcpVK3COXbifmnZoLuxWgBQwtjsSaDGAdr0ReTHM16yI9vU8JNzlFq5Eu2oPp")]
-	[TestCase(new[] { 0, 3 }, "OTkn9daFgDZX6LbmfxI83RSKetJu0APihlsrYoz5pvQw7GyWHEUcN2jBqd4kJ9")]
-	[TestCase(new[] { 0, 4 }, "h2cV5eLNYj1x4ToZpfM90UlgHBOKikQFvnW36AC8zrmuJ7XdRytIGPawqYEbBe")]
-	[TestCase(new[] { 0, 5 }, "7Mf0HeUNkpsZOTvmcj836P9EWKaACBubInFJtwXR2DSzgYGhQV5i4lLxoT1qdU")]
-	[TestCase(new[] { 0, 6 }, "APVSD1ZIY4WGBK75xktMfTev8qsCJw6oyH2j3OnLcXRlhziUmpbuNEar05QCsI")]
-	[TestCase(new[] { 0, 7 }, "P0LUhnlT76rsWSofOeyRGQZv1cC5qu3dtaJYNEXwk8Vpx92bKiHIz4MgmiDOF7")]
-	[TestCase(new[] { 0, 8 }, "xAhypZMXYIGCL4uW0te6lsFHaPc3SiD1TBgw5O7bvodzjqUn89JQRfk2Nvm4JI")]
-	[TestCase(new[] { 0, 9 }, "94dRPIZ6irlXWvTbKywFuAhBoECQOVMjDJp53s2xeqaSzHY8nc17tmkLGwfGNl")]
-	public void EncodeAndDecode_WithMaximumMinLength_ReturnsExactMatch(int[] numbers, string id)
+	[TestCase(new long[] { 1, 2, 3 }, "75JILToVsGerOADWmHlY38xvbaNZKQ9wdFS0B6kcMEtnRpgizhjU42qT1cd0dL")]
+	[TestCase(new long[] { 0, 0 }, "jf26PLNeO5WbJDUV7FmMtlGXps3CoqkHnZ8cYd19yIiTAQuvKSExzhrRghBlwf")]
+	[TestCase(new long[] { 0, 1 }, "vQLUq7zWXC6k9cNOtgJ2ZK8rbxuipBFAS10yTdYeRa3ojHwGnmMV4PDhESI2jL")]
+	[TestCase(new long[] { 0, 2 }, "YhcpVK3COXbifmnZoLuxWgBQwtjsSaDGAdr0ReTHM16yI9vU8JNzlFq5Eu2oPp")]
+	[TestCase(new long[] { 0, 3 }, "OTkn9daFgDZX6LbmfxI83RSKetJu0APihlsrYoz5pvQw7GyWHEUcN2jBqd4kJ9")]
+	[TestCase(new long[] { 0, 4 }, "h2cV5eLNYj1x4ToZpfM90UlgHBOKikQFvnW36AC8zrmuJ7XdRytIGPawqYEbBe")]
+	[TestCase(new long[] { 0, 5 }, "7Mf0HeUNkpsZOTvmcj836P9EWKaACBubInFJtwXR2DSzgYGhQV5i4lLxoT1qdU")]
+	[TestCase(new long[] { 0, 6 }, "APVSD1ZIY4WGBK75xktMfTev8qsCJw6oyH2j3OnLcXRlhziUmpbuNEar05QCsI")]
+	[TestCase(new long[] { 0, 7 }, "P0LUhnlT76rsWSofOeyRGQZv1cC5qu3dtaJYNEXwk8Vpx92bKiHIz4MgmiDOF7")]
+	[TestCase(new long[] { 0, 8 }, "xAhypZMXYIGCL4uW0te6lsFHaPc3SiD1TBgw5O7bvodzjqUn89JQRfk2Nvm4JI")]
+	[TestCase(new long[] { 0, 9 }, "94dRPIZ6irlXWvTbKywFuAhBoECQOVMjDJp53s2xeqaSzHY8nc17tmkLGwfGNl")]
+	public void EncodeAndDecode_WithMaximumMinLength_ReturnsExactMatch(long[] numbers, string id)
 	{
 		var sqids = new SqidsEncoder(new() { MinLength = new SqidsOptions().Alphabet.Length }); // NOTE: This is how we get the default alphabet
 
@@ -24,7 +24,7 @@ public class MinLengthTests
 	[Test, Combinatorial]
 	public void EncodeAndDecode_WithDifferentMinLengths_RespectsMinLengthAndRoundTripsSuccessfully(
 		[ValueSource(nameof(MinLengths))] int minLength,
-		[ValueSource(nameof(Numbers))] int[] numbers
+		[ValueSource(nameof(Numbers))] long[] numbers
 	)
 	{
 		var sqids = new SqidsEncoder(new() { MinLength = minLength });
@@ -34,15 +34,15 @@ public class MinLengthTests
 		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
 	}
 	private static int[] MinLengths => new[] { 0, 1, 5, 10, new SqidsOptions().Alphabet.Length }; // NOTE: We can't use `new SqidsOptions().Alphabet.Length` in the `[Values]` attribute since only constants are allowed for attribute arguments; so we have to use a value source like this.
-	private static int[][] Numbers => new[]
+	private static long[][] Numbers => new[]
 	{
-		new[] { SqidsEncoder.MinValue },
-		new[] { 0, 0, 0, 0, 0 },
-		new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
-		new[] { 100, 200, 300 },
-		new[] { 1_000, 2_000, 3_000 },
-		new[] { 1_000_000 },
-		new[] { SqidsEncoder.MaxValue }
+		new long[] { SqidsEncoder.MinValue },
+		new long[] { 0, 0, 0, 0, 0 },
+		new long[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+		new long[] { 100, 200, 300 },
+		new long[] { 1_000, 2_000, 3_000 },
+		new long[] { 1_000_000 },
+		new long[] { SqidsEncoder.MaxValue }
 	};
 
 	[TestCaseSource(nameof(OutOfRangeMinLengths))]

--- a/test/Sqids.Tests/UniquenessTests.cs
+++ b/test/Sqids.Tests/UniquenessTests.cs
@@ -7,7 +7,7 @@ public class UniquenessTests
 	[TestCase(0, 5)] // NOTE: Multiple numbers
 	[TestCase(0, 1, true)] // NOTE: With maximum padding (i.e. min length)
 	public void EncodeAndDecode_LargeRange_ReturnsUniqueIdsAndRoundTripsSuccessfully(
-		int startingPoint,
+		long startingPoint,
 		int numbersCount,
 		bool maxPadding = false
 	)
@@ -21,7 +21,7 @@ public class UniquenessTests
 
 		var hashSet = new HashSet<string>();
 
-		for (int i = startingPoint; i < startingPoint + range; i++)
+		for (long i = startingPoint; i < startingPoint + range; i++)
 		{
 			var numbers = Enumerable.Repeat(i, numbersCount).ToArray();
 			var id = sqids.Encode(numbers);


### PR DESCRIPTION
This PR replaces `int` support with `long` support.
All tests are updated accordingly.

If there is a need for `EncodeInt`/`DecodeInt` methods or more tests, let me know.

Closes #10