### PR TITLE
Change `Decode`'s return type to `IReadOnlyList`

### DIFF
--- a/src/Sqids/SqidsEncoder.cs
+++ b/src/Sqids/SqidsEncoder.cs
@@ -269,9 +269,9 @@ public sealed class SqidsEncoder
 	/// empty, or includes characters not found in the alphabet.
 	/// </returns>
 #if NET7_0_OR_GREATER
-	public T[] Decode(ReadOnlySpan<char> id)
+	public IReadOnlyList<T> Decode(ReadOnlySpan<char> id)
 #else
-	public int[] Decode(ReadOnlySpan<char> id)
+	public IReadOnlyList<int> Decode(ReadOnlySpan<char> id)
 #endif
 	{
 		if (id.IsEmpty)
@@ -318,7 +318,7 @@ public sealed class SqidsEncoder
 			id = separatorIndex == -1 ? default : id[(separatorIndex + 1)..]; // NOTE: Everything to the right of the separator will be `id` for the next iteration
 
 			if (chunk.IsEmpty)
-				return result.ToArray();
+				return result;
 
 			var alphabetWithoutSeparator = alphabetTemp[1..]; // NOTE: Exclude the first character — which is the separator
 			var decodedNumber = ToNumber(chunk, alphabetWithoutSeparator);
@@ -328,7 +328,7 @@ public sealed class SqidsEncoder
 				ConsistentShuffle(alphabetTemp);
 		}
 
-		return result.ToArray(); // TODO: A way to return an array without creating a new array from the list like this?
+		return result;
 	}
 
 	// NOTE: Implicit `string` => `Span<char>` conversion was introduced in .NET Standard 2.1 (see https://learn.microsoft.com/en-us/dotnet/api/system.string.op_implicit), which means without this overload, calling `Decode` with a string on versions older than .NET Standard 2.1 would require calling `.AsSpan()` on the string, which is cringe.
@@ -342,7 +342,7 @@ public sealed class SqidsEncoder
 	/// if the ID represents a single number); or an empty array if the input ID is null,
 	/// empty, or includes characters not found in the alphabet.
 	/// </returns>
-	public int[] Decode(string id) => Decode(id.AsSpan());
+	public IReadOnlyList<int> Decode(string id) => Decode(id.AsSpan());
 #endif
 
 	private bool IsBlockedId(ReadOnlySpan<char> id)

--- a/test/Sqids.Tests/AlphabetTests.cs
+++ b/test/Sqids.Tests/AlphabetTests.cs
@@ -17,7 +17,7 @@ public class AlphabetTests
 #endif
 
 		sqids.Encode(numbers).ShouldBe(id);
-		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(id).ShouldBe(numbers);
 	}
 
 	[TestCase("abc", new[] { 1, 2, 3 })] // NOTE: Shortest possible alphabet

--- a/test/Sqids.Tests/BlockListTests.cs
+++ b/test/Sqids.Tests/BlockListTests.cs
@@ -11,7 +11,7 @@ public class BlockListTests
 		var sqids = new SqidsEncoder();
 #endif
 
-		sqids.Decode("aho1e").ShouldBeEquivalentTo(new[] { 4572721 });
+		sqids.Decode("aho1e").ShouldBe(new[] { 4572721 });
 		sqids.Encode(4572721).ShouldBe("JExTR");
 	}
 
@@ -27,7 +27,7 @@ public class BlockListTests
 			BlockList = new(),
 		});
 
-		sqids.Decode("aho1e").ShouldBeEquivalentTo(new[] { 4572721 });
+		sqids.Decode("aho1e").ShouldBe(new[] { 4572721 });
 		sqids.Encode(4572721).ShouldBe("aho1e");
 	}
 
@@ -47,13 +47,13 @@ public class BlockListTests
 		});
 
 		// NOTE: Make sure the default blocklist isn't used
-		sqids.Decode("aho1e").ShouldBeEquivalentTo(new[] { 4572721 });
+		sqids.Decode("aho1e").ShouldBe(new[] { 4572721 });
 		sqids.Encode(4572721).ShouldBe("aho1e");
 
 		// NOTE: Make sure the passed blocklist IS used:
-		sqids.Decode("ArUO").ShouldBeEquivalentTo(new[] { 100000 });
+		sqids.Decode("ArUO").ShouldBe(new[] { 100000 });
 		sqids.Encode(100000).ShouldBe("QyG4");
-		sqids.Decode("QyG4").ShouldBeEquivalentTo(new[] { 100000 });
+		sqids.Decode("QyG4").ShouldBe(new[] { 100000 });
 	}
 
 	[Test]
@@ -76,7 +76,7 @@ public class BlockListTests
 		});
 
 		sqids.Encode(1_000_000, 2_000_000).ShouldBe("1aYeB7bRUt");
-		sqids.Decode("1aYeB7bRUt").ShouldBeEquivalentTo(new[] { 1_000_000, 2_000_000 });
+		sqids.Decode("1aYeB7bRUt").ShouldBe(new[] { 1_000_000, 2_000_000 });
 	}
 
 	[Test]
@@ -98,11 +98,11 @@ public class BlockListTests
 			},
 		});
 
-		sqids.Decode("86Rf07").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("se8ojk").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("ARsz1p").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("Q8AI49").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
-		sqids.Decode("5sQRZO").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
+		sqids.Decode("86Rf07").ShouldBe(new[] { 1, 2, 3 });
+		sqids.Decode("se8ojk").ShouldBe(new[] { 1, 2, 3 });
+		sqids.Decode("ARsz1p").ShouldBe(new[] { 1, 2, 3 });
+		sqids.Decode("Q8AI49").ShouldBe(new[] { 1, 2, 3 });
+		sqids.Decode("5sQRZO").ShouldBe(new[] { 1, 2, 3 });
 	}
 
 	[Test]
@@ -120,7 +120,7 @@ public class BlockListTests
 			},
 		});
 
-		sqids.Decode(sqids.Encode(1000)).ShouldBeEquivalentTo(new[] { 1000 });
+		sqids.Decode(sqids.Encode(1000)).ShouldBe(new[] { 1000 });
 	}
 
 	[Test]
@@ -140,7 +140,7 @@ public class BlockListTests
 		});
 
 		sqids.Encode(1, 2, 3).ShouldBe("IBSHOZ"); // NOTE: Without the blocklist, would've been "SQNMPN".
-		sqids.Decode("IBSHOZ").ShouldBeEquivalentTo(new[] { 1, 2, 3 });
+		sqids.Decode("IBSHOZ").ShouldBe(new[] { 1, 2, 3 });
 	}
 
 	[Test]

--- a/test/Sqids.Tests/EncodingTests.cs
+++ b/test/Sqids.Tests/EncodingTests.cs
@@ -26,7 +26,7 @@ public class EncodingTests
 #endif
 
 		sqids.Encode(number).ShouldBe(id);
-		sqids.Decode(id).ShouldBeEquivalentTo(new[] { number });
+		sqids.Decode(id).ShouldBe(new[] { number });
 	}
 
 	// NOTE: Simple case
@@ -65,7 +65,7 @@ public class EncodingTests
 
 		sqids.Encode(numbers).ShouldBe(id);
 		sqids.Encode(numbers.ToList()).ShouldBe(id); // NOTE: Selects the `IEnumerable<int>` overload
-		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(id).ShouldBe(numbers);
 	}
 
 	[TestCase(new[] { 0, 0, 0, 1, 2, 3, 100, 1_000, 100_000, 1_000_000, int.MaxValue })]
@@ -85,7 +85,7 @@ public class EncodingTests
 		var sqids = new SqidsEncoder();
 #endif
 
-		sqids.Decode(sqids.Encode(numbers)).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(sqids.Encode(numbers)).ShouldBe(numbers);
 	}
 
 	[TestCase("*")] // NOTE: Character not found in the alphabet
@@ -127,7 +127,7 @@ public class EncodingTests
 	) where T : unmanaged, IBinaryInteger<T>, IMinMaxValue<T>
 	{
 		var sqids = new SqidsEncoder<T>();
-		sqids.Decode(sqids.Encode(number)).ShouldBeEquivalentTo(new[] { number });
+		sqids.Decode(sqids.Encode(number)).ShouldBe(new[] { number });
 	}
 
 	[TestCaseSource(nameof(MultipleNumbersOfDifferentIntegerTypesTestCaseSource))]
@@ -136,7 +136,7 @@ public class EncodingTests
 	) where T : unmanaged, IBinaryInteger<T>, IMinMaxValue<T>
 	{
 		var sqids = new SqidsEncoder<T>();
-		sqids.Decode(sqids.Encode(numbers)).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(sqids.Encode(numbers)).ShouldBe(numbers);
 	}
 
 	private static TestCaseData[] MultipleNumbersOfDifferentIntegerTypesTestCaseSource => new TestCaseData[]

--- a/test/Sqids.Tests/MinLengthTests.cs
+++ b/test/Sqids.Tests/MinLengthTests.cs
@@ -25,7 +25,7 @@ public class MinLengthTests
 		});
 
 		sqids.Encode(numbers).ShouldBe(id);
-		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(id).ShouldBe(numbers);
 	}
 
 	[TestCaseSource(nameof(IncrementalMinLengthsSource))]
@@ -47,7 +47,7 @@ public class MinLengthTests
 
 		sqids.Encode(numbers).ShouldBe(id);
 		sqids.Encode(numbers).Length.ShouldBeGreaterThanOrEqualTo(minLength);
-		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(id).ShouldBe(numbers);
 	}
 	private static TestCaseData[] IncrementalMinLengthsSource => new TestCaseData[]
 	{
@@ -100,7 +100,7 @@ public class MinLengthTests
 
 		var id = sqids.Encode(numbers);
 		id.Length.ShouldBeGreaterThanOrEqualTo(minLength);
-		sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+		sqids.Decode(id).ShouldBe(numbers);
 	}
 	private static int[] MinLengthsValueSource => new[]
 	{

--- a/test/Sqids.Tests/UniquenessTests.cs
+++ b/test/Sqids.Tests/UniquenessTests.cs
@@ -30,7 +30,7 @@ public class UniquenessTests
 			var numbers = Enumerable.Repeat(i, numbersCount).ToArray();
 			var id = sqids.Encode(numbers);
 			hashSet.Add(id);
-			sqids.Decode(id).ShouldBeEquivalentTo(numbers);
+			sqids.Decode(id).ShouldBe(numbers);
 		}
 
 		hashSet.Count.ShouldBe(range); // NOTE: Ensures that all the IDs were unique.


### PR DESCRIPTION
This avoids the memory allocation that `.ToArray()` entailed.
