### PR TITLE
Add benchmarks

### DIFF
--- a/Sqids.sln
+++ b/Sqids.sln
@@ -11,6 +11,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5B69EBB5-A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sqids.Tests", "test\Sqids.Tests\Sqids.Tests.csproj", "{26D42DEF-5A42-436C-8B80-44AA4917BFC1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{F165CB60-0269-4F53-8F6C-F61EF172947C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sqids.Benchmarks", "benchmark\Sqids.Benchmarks\Sqids.Benchmarks.csproj", "{7892A604-1098-4088-A806-01787BE78521}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,9 +32,14 @@ Global
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7892A604-1098-4088-A806-01787BE78521}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7892A604-1098-4088-A806-01787BE78521}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7892A604-1098-4088-A806-01787BE78521}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7892A604-1098-4088-A806-01787BE78521}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{387B307E-04C6-4B8E-BE50-03FF91307070} = {FC64F776-DE51-4BFF-91D5-0ECFEEF5CCAC}
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1} = {5B69EBB5-A05C-4DCB-9355-D010B0A093AE}
+		{7892A604-1098-4088-A806-01787BE78521} = {F165CB60-0269-4F53-8F6C-F61EF172947C}
 	EndGlobalSection
 EndGlobal

--- a/benchmark/Sqids.Benchmarks/EncodeBenchmark.cs
+++ b/benchmark/Sqids.Benchmarks/EncodeBenchmark.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Sqids.Benchmarks;
+
+[MemoryDiagnoser]
+public class EncodeBenchmark
+{
+#if NET7_0_OR_GREATER
+	private SqidsEncoder<int> _encoder = new SqidsEncoder<int>();
+#else
+	private SqidsEncoder _encoder = new SqidsEncoder();
+#endif
+
+	[Benchmark]
+	public string Encode() => _encoder.Encode(42);
+
+	[Benchmark]
+	public IReadOnlyList<int> Decode() => _encoder.Decode("Jg");
+}

--- a/benchmark/Sqids.Benchmarks/EncodeBenchmark.cs
+++ b/benchmark/Sqids.Benchmarks/EncodeBenchmark.cs
@@ -12,8 +12,20 @@ public class EncodeBenchmark
 #endif
 
 	[Benchmark]
-	public string Encode() => _encoder.Encode(42);
+	public string EncodeSmall() => _encoder.Encode(42);
 
 	[Benchmark]
-	public IReadOnlyList<int> Decode() => _encoder.Decode("Jg");
+	public string EncodeBig() => _encoder.Encode(int.MaxValue);
+
+	[Benchmark]
+	public string EncodeMany() => _encoder.Encode(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+	[Benchmark]
+	public IReadOnlyList<int> DecodeSmall() => _encoder.Decode("Jg");
+
+	[Benchmark]
+	public IReadOnlyList<int> DecodeBig() => _encoder.Decode("UKrsQ1F");
+
+	[Benchmark]
+	public IReadOnlyList<int> DecodeMany() => _encoder.Decode("hwB5vcCxfAyBnVKMtAaV");
 }

--- a/benchmark/Sqids.Benchmarks/Program.cs
+++ b/benchmark/Sqids.Benchmarks/Program.cs
@@ -1,0 +1,20 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace Sqids.Benchmarks;
+
+public static class Program
+{
+	public static void Main(string[] args)
+	{
+		IConfig config = ManualConfig.CreateMinimumViable()
+			.AddJob(Job.Default.WithRuntime(ClrRuntime.Net472))
+			.AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
+			.AddJob(Job.Default.WithRuntime(CoreRuntime.Core70))
+			.AddJob(Job.Default.WithRuntime(CoreRuntime.Core80));
+
+		BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+	}
+}

--- a/benchmark/Sqids.Benchmarks/Sqids.Benchmarks.csproj
+++ b/benchmark/Sqids.Benchmarks/Sqids.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<!-- NOTE: `net472` is used for testing `netstandard2.0` -->
+		<TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+		<LangVersion>12.0</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<OutputType>exe</OutputType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Sqids\Sqids.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added a benchmark project using BenchmarkDotNet which measures a few scenarios on all supported runtimes. The scenarios are:
- Encoding a small integer
- Encoding a large integer
- Encoding multiple integers

The same cases are covered for decoding. The project is currently using a benchmark switcher to make space for future benchmarks, but feel free to change it to just run the one benchmark.