### PR TITLE
Performance improvements for Encoding & Decoding

### DIFF
--- a/Sqids.sln
+++ b/Sqids.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5B69EBB5-A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sqids.Tests", "test\Sqids.Tests\Sqids.Tests.csproj", "{26D42DEF-5A42-436C-8B80-44AA4917BFC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sqids.Benchmarks", "src\Sqids.Benchmarks\Sqids.Benchmarks.csproj", "{FA1E422D-46BC-462C-9FB3-695BB177268B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,9 +30,14 @@ Global
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA1E422D-46BC-462C-9FB3-695BB177268B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA1E422D-46BC-462C-9FB3-695BB177268B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA1E422D-46BC-462C-9FB3-695BB177268B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA1E422D-46BC-462C-9FB3-695BB177268B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{387B307E-04C6-4B8E-BE50-03FF91307070} = {FC64F776-DE51-4BFF-91D5-0ECFEEF5CCAC}
 		{26D42DEF-5A42-436C-8B80-44AA4917BFC1} = {5B69EBB5-A05C-4DCB-9355-D010B0A093AE}
+		{FA1E422D-46BC-462C-9FB3-695BB177268B} = {FC64F776-DE51-4BFF-91D5-0ECFEEF5CCAC}
 	EndGlobalSection
 EndGlobal

--- a/src/Sqids.Benchmarks/Program.cs
+++ b/src/Sqids.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+	.FromAssembly(typeof(Program).Assembly)
+	.RunAllJoined();

--- a/src/Sqids.Benchmarks/SqidIdDecoderBenchmark.cs
+++ b/src/Sqids.Benchmarks/SqidIdDecoderBenchmark.cs
@@ -1,0 +1,15 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sqids.Benchmarks;
+
+[MemoryDiagnoser]
+public class SqidIdDecoderBenchmark
+{
+	private readonly SqidsEncoder<long> _sqidsEncoder = new ();
+
+	[Params("Uk", "DzPWXTJADcE", "bMZn4Y5Fq8QTCJoLjxPvGfB9Dh6mlz1Sgcu0KpkMyOEiIdrsHRW2VZtweX3aA7UNbhFm8ZG04y52lzNU6di")]
+	public string EncodedId { get; set; } = string.Empty;
+
+	[Benchmark]
+	public IReadOnlyList<long> Decode() => _sqidsEncoder.Decode(EncodedId);
+}

--- a/src/Sqids.Benchmarks/SqidIdEncoderBenchmark.cs
+++ b/src/Sqids.Benchmarks/SqidIdEncoderBenchmark.cs
@@ -1,0 +1,15 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Sqids.Benchmarks;
+
+[MemoryDiagnoser]
+public class SqidIdEncoderBenchmark
+{
+	private readonly SqidsEncoder<long> _sqidsEncoder = new ();
+
+	[Params(1, 100, 1_000, 1_000_000, 1_000_000_000)]
+	public int Id { get; set; }
+
+	[Benchmark]
+	public string Encode() => _sqidsEncoder.Encode(Id);
+}

--- a/src/Sqids.Benchmarks/Sqids.Benchmarks.csproj
+++ b/src/Sqids.Benchmarks/Sqids.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Sqids\Sqids.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Sqids/SqidsEncoder.cs
+++ b/src/Sqids/SqidsEncoder.cs
@@ -30,6 +30,10 @@ public sealed class SqidsEncoder
 	private readonly int _minLength;
 	private readonly string[] _blockList;
 
+#if NET8_0_OR_GREATER
+	private readonly SearchValues<char> _digitValues = SearchValues.Create("0123456789");
+#endif
+
 #if NET7_0_OR_GREATER
 	/// <summary>
 	/// Initializes a new instance of <see cref="SqidsEncoder{T}" /> with the default options.
@@ -380,7 +384,7 @@ public sealed class SqidsEncoder
 				id.Equals(word.AsSpan(), StringComparison.OrdinalIgnoreCase))
 				return true;
 
-			if (word.Any(char.IsDigit) &&
+			if (ContainsDigit(word.AsSpan()) &&
 				(id.StartsWith(word.AsSpan(), StringComparison.OrdinalIgnoreCase) ||
 				 id.EndsWith(word.AsSpan(), StringComparison.OrdinalIgnoreCase)))
 				return true;
@@ -447,5 +451,20 @@ public sealed class SqidsEncoder
 			result = result * alphabet.Length + alphabet.IndexOf(character);
 #endif
 		return result;
+	}
+
+	private bool ContainsDigit(ReadOnlySpan<char> value)
+	{
+#if NET8_0_OR_GREATER
+		return value.ContainsAny(_digitValues);
+#else
+		for (var i = 0; i < value.Length; i++)
+		{
+			if (char.IsDigit(value[i]))
+				return true;
+		}
+
+		return false;
+#endif
 	}
 }

--- a/src/Sqids/SqidsEncoder.cs
+++ b/src/Sqids/SqidsEncoder.cs
@@ -32,6 +32,7 @@ public sealed class SqidsEncoder
 
 #if NET8_0_OR_GREATER
 	private readonly SearchValues<char> _digitValues = SearchValues.Create("0123456789");
+	private readonly SearchValues<char> _alphabetValues;
 #endif
 
 #if NET7_0_OR_GREATER
@@ -124,6 +125,9 @@ public sealed class SqidsEncoder
 		_blockList = blockList.ToArray(); // NOTE: Arrays are faster to iterate than HashSets, so we construct an array here.
 
 		_alphabet = options.Alphabet.ToCharArray();
+#if NET8_0_OR_GREATER
+		_alphabetValues = SearchValues.Create(_alphabet);
+#endif
 		ConsistentShuffle(_alphabet);
 	}
 
@@ -316,12 +320,16 @@ public sealed class SqidsEncoder
 			return Array.Empty<int>();
 #endif
 
+#if NET8_0_OR_GREATER
+		foreach (var c in id)
+		{
+			if (!_alphabetValues.Contains(c))
+				return [];
+		}
+#else
 		foreach (char c in id)
 			if (!_alphabet.Contains(c))
-#if NET7_0_OR_GREATER
-				return Array.Empty<T>();
-#else
-				return Array.Empty<int>();
+				return [];
 #endif
 
 		var alphabetSpan = _alphabet.AsSpan();

--- a/src/Sqids/StringBuilderPool.cs
+++ b/src/Sqids/StringBuilderPool.cs
@@ -1,0 +1,104 @@
+using System.Collections.Concurrent;
+
+namespace Sqids;
+
+/// <summary>
+/// Provides a thread-safe object pool for reusing <see cref="StringBuilder"/> instances.
+/// This helps to reduce memory allocations and garbage collection pressure, particularly
+/// in scenarios involving frequent string manipulations.
+/// </summary>
+/// <remarks>
+/// This class implements the Singleton pattern via the <see cref="Instance"/> property to ensure
+/// a single, globally accessible pool. It uses a <see cref="ConcurrentBag{T}"/> internally,
+/// making the <see cref="Rent"/> and <see cref="Return"/> operations thread-safe.
+///
+/// Usage pattern:
+/// <code>
+/// var sb = StringBuilderPool.Instance.Rent();
+/// try
+/// {
+///     // Use the StringBuilder instance (sb)
+///     sb.Append("example");
+///     // ... other operations ...
+///     string result = sb.ToString();
+/// }
+/// finally
+/// {
+///     StringBuilderPool.Instance.Return(sb);
+/// }
+/// </code>
+/// It is crucial to always return the rented <see cref="StringBuilder"/> instance back to the pool
+/// using the <see cref="Return"/> method within a finally block to prevent resource leaks
+/// and ensure the pool remains effective. Failure to return instances will lead to the pool
+/// creating new instances when depleted, negating the benefits of pooling.
+/// </remarks>
+public class StringBuilderPool
+{
+	private readonly ConcurrentBag<StringBuilder> _pool = [];
+	private static StringBuilderPool? _instance;
+
+	/// <summary>
+	/// Gets the singleton instance of the <see cref="StringBuilderPool"/>.
+	/// </summary>
+	/// <value>The singleton <see cref="StringBuilderPool"/> instance.</value>
+	public static StringBuilderPool Instance => _instance ??= new StringBuilderPool();
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="StringBuilderPool"/> class
+	/// and optionally pre-populates the pool.
+	/// </summary>
+	/// <param name="initialCapacity">The initial number of <see cref="StringBuilder"/> instances to create and add to the pool. Defaults to 16.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="initialCapacity"/> is less than 0.</exception>
+	public StringBuilderPool(int initialCapacity = 16)
+	{
+		if (initialCapacity < 0) throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+
+		// Pre-populate the pool for better initial performance
+		for (var i = 0; i < initialCapacity; i++)
+		{
+			_pool.Add(new StringBuilder());
+		}
+	}
+
+	/// <summary>
+	/// Rents a <see cref="StringBuilder"/> instance from the pool.
+	/// </summary>
+	/// <returns>
+	/// A cleared <see cref="StringBuilder"/> instance obtained from the pool if available;
+	/// otherwise, a new <see cref="StringBuilder"/> instance.
+	/// </returns>
+	/// <remarks>
+	/// The returned <see cref="StringBuilder"/> is cleared before being provided to the caller.
+	/// If the pool is empty, a new instance is allocated. Remember to return the instance
+	/// using <see cref="Return"/> when finished.
+	/// </remarks>
+	public StringBuilder Rent()
+	{
+		if (_pool.TryTake(out var sb))
+		{
+			// Ensure the StringBuilder is clean before reuse
+			sb.Clear();
+			return sb;
+		}
+
+		// Pool is empty, create a new instance
+		return new StringBuilder();
+	}
+
+	/// <summary>
+	/// Returns a <see cref="StringBuilder"/> instance to the pool.
+	/// </summary>
+	/// <param name="sb">The <see cref="StringBuilder"/> instance to return to the pool.</param>
+	/// <remarks>
+	/// The provided <see cref="StringBuilder"/> instance is cleared before being added back
+	/// to the pool, preparing it for the next renter. It is crucial to call this method
+	/// for every instance obtained via <see cref="Rent"/> to ensure proper pool functioning.
+	/// Typically called within a `finally` block.
+	/// </remarks>
+	public void Return(StringBuilder sb)
+	{
+		// Clear the StringBuilder before putting it back into the pool
+		sb.Clear();
+		_pool.Add(sb);
+	}
+}


### PR DESCRIPTION
Hey, I benchmarked SqidIdEncoder and saw potential for performance improvements. So I went ahead and implemented some performance improvements. While some of them only apply to .net 8 and above, I hope they fit in with the vision of this project.

- Unit tests still run successful

## Benchmark source code 

### Source

```c#
using BenchmarkDotNet.Attributes;

namespace Sqids.Benchmarks;

[MemoryDiagnoser]
public class SqidIdDecoderBenchmark
{
	private readonly SqidsEncoder<long> _sqidsEncoder = new ();

	[Params("Uk", "DzPWXTJADcE", "bMZn4Y5Fq8QTCJoLjxPvGfB9Dh6mlz1Sgcu0KpkMyOEiIdrsHRW2VZtweX3aA7UNbhFm8ZG04y52lzNU6di")]
	public string EncodedId { get; set; } = string.Empty;

	[Benchmark]
	public IReadOnlyList<long> Decode() => _sqidsEncoder.Decode(EncodedId);
}

```

```c#
using BenchmarkDotNet.Attributes;

namespace Sqids.Benchmarks;

[MemoryDiagnoser]
public class SqidIdEncoderBenchmark
{
	private readonly SqidsEncoder<long> _sqidsEncoder = new ();

	[Params(1, 100, 1_000, 1_000_000, 1_000_000_000)]
	public int Id { get; set; }

	[Benchmark]
	public string Encode() => _sqidsEncoder.Encode(Id);
}
```

## Benchmark before

| Type                   | Method | Id         | EncodedId            |         Mean |     Error |    StdDev |   Gen0 | Allocated |
| ---------------------- | ------ | ---------- | -------------------- | -----------: | --------: | --------: | -----: | --------: |
| SqidIdEncoderBenchmark | Encode | 1          | ?                    |    339.68 ns |  0.236 ns |  0.197 ns | 0.0420 |     264 B |
| SqidIdEncoderBenchmark | Encode | 100        | ?                    |    603.40 ns |  1.545 ns |  1.445 ns | 0.0782 |     496 B |
| SqidIdEncoderBenchmark | Encode | 1000       | ?                    |    604.90 ns |  1.283 ns |  1.200 ns | 0.0782 |     496 B |
| SqidIdEncoderBenchmark | Encode | 1000000    | ?                    |  7,046.74 ns |  8.617 ns |  8.060 ns | 0.9918 |    6224 B |
| SqidIdEncoderBenchmark | Encode | 1000000000 | ?                    | 14,116.36 ns | 20.469 ns | 18.145 ns | 1.8616 |   11680 B |
| SqidIdDecoderBenchmark | Decode | ?          | bMZn4(...)NU6di [83] |  1,121.78 ns |  2.426 ns |  2.026 ns | 0.0134 |      88 B |
| SqidIdDecoderBenchmark | Decode | ?          | DzPWXTJADcE          |    567.55 ns |  0.405 ns |  0.379 ns | 0.0134 |      88 B |
| SqidIdDecoderBenchmark | Decode | ?          | Uk                   |     68.80 ns |  0.062 ns |  0.058 ns | 0.0139 |      88 B |

## Benchmark after

| Type                   | Method | Id         | EncodedId            |        Mean |     Error |     StdDev |      Median |   Gen0 | Allocated |
| ---------------------- | ------ | ---------- | -------------------- | ----------: | --------: | ---------: | ----------: | -----: | --------: |
| SqidIdEncoderBenchmark | Encode | 1          | ?                    |   340.35 ns |  1.327 ns |   1.241 ns |   340.29 ns | 0.0048 |      32 B |
| SqidIdEncoderBenchmark | Encode | 100        | ?                    |   496.70 ns | 11.138 ns |  31.596 ns |   482.06 ns | 0.0048 |      32 B |
| SqidIdEncoderBenchmark | Encode | 1000       | ?                    |   541.43 ns | 10.565 ns |  24.063 ns |   529.16 ns | 0.0048 |      32 B |
| SqidIdEncoderBenchmark | Encode | 1000000    | ?                    | 3,085.81 ns | 59.130 ns | 149.430 ns | 3,018.31 ns | 0.0038 |      32 B |
| SqidIdEncoderBenchmark | Encode | 1000000000 | ?                    | 5,673.26 ns | 53.813 ns |  50.337 ns | 5,674.56 ns |      - |      40 B |
| SqidIdDecoderBenchmark | Decode | ?          | bMZn4(...)NU6di [83] |   648.11 ns |  7.812 ns |   7.307 ns |   645.51 ns | 0.0134 |      88 B |
| SqidIdDecoderBenchmark | Decode | ?          | DzPWXTJADcE          |   506.34 ns |  3.831 ns |   3.584 ns |   506.60 ns | 0.0134 |      88 B |
| SqidIdDecoderBenchmark | Decode | ?          | Uk                   |    58.11 ns |  1.220 ns |   2.875 ns |    56.97 ns | 0.0140 |      88 B |
